### PR TITLE
Updated Group, Playfield, and Spawner files.

### DIFF
--- a/TetrisGame/Assets/Scenes/SampleScene.unity
+++ b/TetrisGame/Assets/Scenes/SampleScene.unity
@@ -656,7 +656,7 @@ Transform:
   m_GameObject: {fileID: 744413185}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.5, y: 10, z: 0}
+  m_LocalPosition: {x: 19.5, y: 10, z: 0}
   m_LocalScale: {x: 1, y: 40, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -973,8 +973,8 @@ Transform:
   m_GameObject: {fileID: 1244649023}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4.5, y: -1, z: 0}
-  m_LocalScale: {x: 11, y: 1, z: 1}
+  m_LocalPosition: {x: 9.5, y: -1, z: 0}
+  m_LocalScale: {x: 20, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/TetrisGame/Assets/Scripts/Group.cs
+++ b/TetrisGame/Assets/Scripts/Group.cs
@@ -6,6 +6,7 @@ public class Group : MonoBehaviour
 {
     // Time since last gravity tick
     float lastFall = 0;
+    public float blockFallTime;
 
     // Start is called before the first frame update
     void Start()
@@ -21,9 +22,20 @@ public class Group : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
+        /*if(Input.GetMouseButtonDown(0))
+        {
+            Debug.Log("Fire");
+            if(Time.timeScale <= 99)
+            Time.timeScale += 1f;
+        }
+        if (Input.GetMouseButtonDown(1))
+        {
+            Debug.Log("Alt-Fire");
+            Time.timeScale = 1;
+        }*/
 
         // Rotate
-        if (Input.GetKeyDown(KeyCode.UpArrow) || Input.GetKeyDown(KeyCode.E))
+        if (Input.GetKeyDown(KeyCode.UpArrow) || Input.GetKeyDown(KeyCode.E) || Input.GetKeyDown(KeyCode.Q))
         {
             transform.Rotate(0, 0, -90);
 
@@ -49,8 +61,8 @@ public class Group : MonoBehaviour
         }
 
         // Move Downwards and Fall
-        else if (Input.GetKeyDown(KeyCode.DownArrow) ||
-         Time.time - lastFall >= 1)
+        else if (Input.GetKeyDown(KeyCode.S) || Input.GetKeyDown(KeyCode.DownArrow) ||
+         Time.time - lastFall >= blockFallTime)
         {
             // Modify position
             transform.position += new Vector3(0, -1, 0);

--- a/TetrisGame/Assets/Scripts/Playfield.cs
+++ b/TetrisGame/Assets/Scripts/Playfield.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class Playfield : MonoBehaviour
 {
     // The Grid itself
-    public static int w = 10;
-    public static int h = 200;
+    public static int w = 20;
+    public static int h = 2000;
     public static Transform[,] grid = new Transform[w, h];
 
     // Start is called before the first frame update

--- a/TetrisGame/Assets/Scripts/Spawner.cs
+++ b/TetrisGame/Assets/Scripts/Spawner.cs
@@ -8,6 +8,8 @@ public class Spawner : MonoBehaviour
     public GameObject[] groups;
     public Sprite[] sprites;
     public GameObject player;
+    float fallTime = 1;
+    int lastTime = 0;
 
     // Start is called before the first frame update
     void Start()
@@ -19,11 +21,19 @@ public class Spawner : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+
     }
 
     public void spawnNext()
     {
+        int timeCheck = (int)Time.time; //Throw time into an int so we can drop the numbers after the decimal.
+        if ((timeCheck > 1 && ((timeCheck % 10) == 0)) || ((timeCheck - lastTime) > 100) ) //Check to see if 10 seconds passed, if so then make blocks fall faster. 
+        {
+            timeCheck++;
+            fallTime -= .1f;
+            lastTime += 100;
+        }
+
         // Random Index
         int i = Random.Range(0, groups.Length);
         
@@ -34,7 +44,46 @@ public class Spawner : MonoBehaviour
         int m = Random.Range(0, sprites.Length);
 
         // Spawn Group at current Position
-        int x = Random.Range(2, 9);
+        int playfieldEdge = Playfield.w - 1;
+        int x = Random.Range(1, playfieldEdge); //Range of 1 to Playfield.w - 1, 1 is the left of our playfield and 19 is the right of the playfield.
+        switch (i)
+        {
+            case 0:             //I block
+                //This block doesn't need to be moved over, leave it where it is.
+                break;
+            case 1:             //J block
+                if (x == 1)
+                    x++; //This block's center will spawn it out of bounds only on the left wall, so move it right one block.
+                break;
+            case 2:             //L block
+                if (x == playfieldEdge)
+                    x--; //This block's center will spawn it out of bounds only on the right wall, so move it left one block.
+                break;
+            case 3:             //O block
+                if (x == playfieldEdge)
+                    x--; //This block's center will spawn it out of bounds only on the right wall, so move it left one block.
+                break;
+            case 4:             //S  block
+                if (x == 1)
+                    x++; //This block's center will spawn it out of bounds on the left wall, so move it right one block.
+                else if (x == playfieldEdge)
+                    x--; //This block's center will spawn it out of bounds on the right wall, so move it left one block.
+                break;
+            case 5:             //T block
+                if(x == 1)
+                    x++; //This block's center will spawn it out of bounds on the left wall, so move it right one block.
+                else if(x == playfieldEdge)
+                    x--; //This block's center will spawn it out of bounds on the right wall, so move it left one block.
+                break;
+            case 6:             //Z block
+                if (x == 1)
+                    x++; //This block's center will spawn it out of bounds on the left wall, so move it right one block.
+                else if (x == playfieldEdge)
+                    x--; //This block's center will spawn it out of bounds on the right wall, so move it left one block.
+                break;
+            default:
+                break;
+        }
         int y = (int)(player.transform.position.y + 14);
         Vector3 pos = transform.position;
         pos.x = x;
@@ -42,6 +91,7 @@ public class Spawner : MonoBehaviour
         GameObject spawnedBlock = Instantiate(groups[i],
                     pos,
                     Quaternion.identity);
+        spawnedBlock.GetComponent<Group>().blockFallTime = fallTime;
 
         //Here we set the sprites of the objects
         spawnedBlock.transform.GetChild(0).GetComponent<SpriteRenderer>().sprite = sprites[j];


### PR DESCRIPTION
This pull request will make the game's playfield double in width size, along with a simple added difficulty that changes every 100 seconds. 

Group.cs was updated to include a blockFallTime variable that can be edited later on to increase the fall speed of blocks. Added mouse interactions that are commented out for now (was used to up the timescale). Added Q key for rotate and S key for quicker drop.

Increased the playfield width by 10 and height by 1800. The width is now 20 and height is 2000. Game is much less performant when height is increased to 2 million, probably because we are doing 2 million block checks each time the block falls a grid space.

Updated Spawner.cs to have fallTime and lastTime variables. Fall time is the amount we want to take away from total block fall time, and last time is used to track 100 seconds going by which will then lower the 1s block fall by 0.1 per every 100 seconds. Added a switch statement to catch blocks so they do not spawn outside the bounds of the walls.